### PR TITLE
fix: Log jumping & some optimizations

### DIFF
--- a/src/features/Log/Log.module.css
+++ b/src/features/Log/Log.module.css
@@ -37,8 +37,13 @@ table.logTable {
     tr.infoRow:hover {
         background-color: unset;
     }
+    td.iconColumn {
+        width: 4rem;
+        height: 4rem;
+    }
     td.ctaColumn {
         cursor: initial;
+        width: 3rem;
     }
     .durationColumn {
         display: flex;

--- a/src/features/Log/Log.module.css
+++ b/src/features/Log/Log.module.css
@@ -49,6 +49,9 @@ table.logTable {
         display: flex;
         justify-content: flex-end;
     }
+    .hidden {
+        visibility: hidden;
+    }
 
     @media (max-width: $mantine-breakpoint-xs) {
         margin-inline: -1rem;

--- a/src/features/Log/LogEntries.tsx
+++ b/src/features/Log/LogEntries.tsx
@@ -87,6 +87,8 @@ export const LogEntries = (props: LogEntriesProps) => {
         );
     }
 
+    const now = dayjs();
+
     return (
         <>
             {entriesGroupsIterable.map(([groupTitle, groupedEntries]) => {
@@ -116,6 +118,7 @@ export const LogEntries = (props: LogEntriesProps) => {
                                 <LogEntryDisplay
                                     key={groupedEntry.metadata.uid}
                                     entry={groupedEntry}
+                                    now={now}
                                     onOpenConfirmDelete={
                                         handleOpenConfirmDelete
                                     }

--- a/src/features/Log/LogEntryDisplay.tsx
+++ b/src/features/Log/LogEntryDisplay.tsx
@@ -112,10 +112,11 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
                                     title={
                                         <Duration duration={entryDuration} />
                                     }
+                                    shouldPreventShrink
                                 />
                             </Box>
                         ) : (
-                            <Box style={{ visibility: 'hidden' }}>.</Box>
+                            invisibleSpacer
                         )}
                         {entryStartedTimeAgo && (
                             <Box className={classes.durationColumn}>
@@ -127,6 +128,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
                                             duration={entryStartedTimeAgo}
                                         />
                                     }
+                                    shouldPreventShrink
                                 />
                             </Box>
                         )}
@@ -166,3 +168,5 @@ const hasEndedAt = (
 const onEventStopPropagation = (event: React.MouseEvent<unknown>) => {
     event.stopPropagation();
 };
+
+const invisibleSpacer = <Box style={{ visibility: 'hidden' }}>.</Box>;

--- a/src/features/Log/LogEntryDisplay.tsx
+++ b/src/features/Log/LogEntryDisplay.tsx
@@ -1,5 +1,5 @@
-import { Box, rem, Table } from '@mantine/core';
-import dayjs from 'dayjs';
+import { Box, Table } from '@mantine/core';
+import dayjs, { Dayjs } from 'dayjs';
 import { IconCalendar, IconClock } from '@tabler/icons-react';
 import {
     DateISO8601,
@@ -21,11 +21,12 @@ import { TimeAgo } from '../../common/features/TimeAgo/TimeAgo';
 
 interface LogEntryProps {
     entry: LogEntry;
+    now: Dayjs;
     onOpenConfirmDelete: (entry: LogEntry) => void;
 }
 
 const LogEntryDisplayBase = (props: LogEntryProps) => {
-    const { entry, onOpenConfirmDelete } = props;
+    const { entry, now, onOpenConfirmDelete } = props;
     const navigate = useNavigate();
 
     const { ref, inViewport } = useInViewport();
@@ -67,7 +68,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
         return dayjs.duration(entryTime.ended.diff(entryTime.started));
     })();
     const entryStartedTimeAgo = (() => {
-        const startedTimeAgo = dayjs.duration(dayjs().diff(entryTime.started));
+        const startedTimeAgo = dayjs.duration(now.diff(entryTime.started));
 
         if (startedTimeAgo.asHours() > 24) {
             return;
@@ -82,7 +83,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
             ref={ref}
             onClick={handleGotoEvent}
         >
-            <Table.Td w={rem(64)} h={rem(64)}>
+            <Table.Td className={classes.iconColumn}>
                 <EntryTypeIcon
                     entryType={entry.entryType}
                     isInProgress={isInProgress}
@@ -95,9 +96,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
                             started={entryTime.started}
                             ended={entryTime.ended}
                         />
-                        <Box>
-                            <LogEntryEventMiniDetails event={entry} />
-                        </Box>
+                        <LogEntryEventMiniDetails event={entry} />
                     </>
                 )}
             </Table.Td>
@@ -108,7 +107,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
                             <Box className={classes.durationColumn}>
                                 <MiniDetailsEntry
                                     size="sm"
-                                    icon={<IconClock title="Duration" />}
+                                    icon={iconDurationEl}
                                     title={
                                         <Duration duration={entryDuration} />
                                     }
@@ -122,7 +121,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
                             <Box className={classes.durationColumn}>
                                 <MiniDetailsEntry
                                     size="sm"
-                                    icon={<IconCalendar title="Created" />}
+                                    icon={iconCreatedEl}
                                     title={
                                         <TimeAgo
                                             duration={entryStartedTimeAgo}
@@ -138,7 +137,6 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
             <Table.Td
                 onClick={onEventStopPropagation}
                 className={classes.ctaColumn}
-                w={rem(48)}
                 align="right"
             >
                 {inViewport && (
@@ -170,3 +168,5 @@ const onEventStopPropagation = (event: React.MouseEvent<unknown>) => {
 };
 
 const invisibleSpacer = <Box style={{ visibility: 'hidden' }}>.</Box>;
+const iconDurationEl = <IconClock title="Duration" />;
+const iconCreatedEl = <IconCalendar title="Created" />;

--- a/src/features/Log/LogEntryDisplay.tsx
+++ b/src/features/Log/LogEntryDisplay.tsx
@@ -10,7 +10,6 @@ import classes from './Log.module.css';
 import { EntryTypeIcon } from './LogEntryDisplay/EntryTypeIcon';
 import { EntryActions } from './LogEntryDisplay/EntryActions';
 import { EntryDates } from './LogEntryDisplay/EntryDates';
-import { isTimedEntry } from '../../common/utils/entryGuards';
 import { routes } from '../../common/routes';
 import { useInViewport } from '@mantine/hooks';
 import React, { useCallback, useMemo } from 'react';
@@ -27,8 +26,6 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
     const navigate = useNavigate();
 
     const { ref, inViewport } = useInViewport();
-
-    const isInProgress = isTimedEntry(entry) && !entry.params.endedAt;
 
     const handleGotoEvent = useCallback(() => {
         void navigate(routes.eventView(entry.metadata.uid));
@@ -65,10 +62,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
             onClick={handleGotoEvent}
         >
             <Table.Td className={classes.iconColumn}>
-                <EntryTypeIcon
-                    entryType={entry.entryType}
-                    isInProgress={isInProgress}
-                />
+                {inViewport && <EntryTypeIcon entry={entry} />}
             </Table.Td>
             <Table.Td>
                 {inViewport && (

--- a/src/features/Log/LogEntryDisplay/EntryActions.module.css
+++ b/src/features/Log/LogEntryDisplay/EntryActions.module.css
@@ -1,6 +1,6 @@
 .iconOpenMenu {
-    width: '70%';
-    height: '70%';
+    width: 1rem;
+    height: 1rem;
 }
 .menuItemIcon {
     width: 0.875rem;

--- a/src/features/Log/LogEntryDisplay/EntryDurationColumn.tsx
+++ b/src/features/Log/LogEntryDisplay/EntryDurationColumn.tsx
@@ -1,0 +1,67 @@
+import dayjs from 'dayjs';
+import React, { useMemo } from 'react';
+import classes from '../Log.module.css';
+import { MiniDetailsEntry } from '../LogEntryEventMiniDetails/MiniDetailsEntry/MiniDetailsEntry';
+import { Duration } from '../../../common/features/Duration/Duration';
+import { TimeAgo } from '../../../common/features/TimeAgo/TimeAgo';
+import { IconCalendar, IconClock } from '@tabler/icons-react';
+
+interface EntryDurationColumnProps {
+    started: dayjs.Dayjs;
+    ended: dayjs.Dayjs | null | undefined;
+    now: dayjs.Dayjs;
+}
+
+const EntryDurationColumnBase = (props: EntryDurationColumnProps) => {
+    const { started, ended, now } = props;
+
+    const entryDuration = useMemo(() => {
+        if (!ended) {
+            return;
+        }
+
+        return dayjs.duration(ended.diff(started));
+    }, [ended, started]);
+    const entryStartedTimeAgo = useMemo(() => {
+        const startedTimeAgo = dayjs.duration(now.diff(started));
+
+        if (startedTimeAgo.asHours() > 24) {
+            return;
+        }
+
+        return startedTimeAgo;
+    }, [now, started]);
+
+    return (
+        <div>
+            {entryDuration ? (
+                <div className={classes.durationColumn}>
+                    <MiniDetailsEntry
+                        size="sm"
+                        icon={iconDurationEl}
+                        title={<Duration duration={entryDuration} />}
+                        shouldPreventShrink
+                    />
+                </div>
+            ) : (
+                invisibleSpacer
+            )}
+            {entryStartedTimeAgo && (
+                <div className={classes.durationColumn}>
+                    <MiniDetailsEntry
+                        size="sm"
+                        icon={iconCreatedEl}
+                        title={<TimeAgo duration={entryStartedTimeAgo} />}
+                        shouldPreventShrink
+                    />
+                </div>
+            )}
+        </div>
+    );
+};
+
+export const EntryDurationColumn = React.memo(EntryDurationColumnBase);
+
+const invisibleSpacer = <div className={classes.hidden}>.</div>;
+const iconDurationEl = <IconClock title="Duration" />;
+const iconCreatedEl = <IconCalendar title="Created" />;

--- a/src/features/Log/LogEntryDisplay/EntryTypeIcon.tsx
+++ b/src/features/Log/LogEntryDisplay/EntryTypeIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EntryType } from '../../../common/store/types/storeData.types';
+import { LogEntry } from '../../../common/store/types/storeData.types';
 import {
     mapEntryTypeToColor,
     mapEntryTypeToIcon,
@@ -8,18 +8,21 @@ import {
 import { Avatar, Indicator } from '@mantine/core';
 
 import classes from './EntryTypeIcon.module.css';
+import { isTimedEntry } from '../../../common/utils/entryGuards';
 
 interface EntryTypeIconProps {
-    entryType: EntryType;
-    isInProgress: boolean;
+    entry: LogEntry;
 }
 
 const EntryTypeIconBase = (props: EntryTypeIconProps) => {
-    const IconComponent = mapEntryTypeToIcon(props.entryType);
+    const IconComponent = mapEntryTypeToIcon(props.entry.entryType);
+
+    const isInProgress =
+        isTimedEntry(props.entry) && !props.entry.params.endedAt;
 
     return (
         <Indicator
-            disabled={!props.isInProgress}
+            disabled={!isInProgress}
             inline
             processing
             color="indigo"
@@ -29,8 +32,8 @@ const EntryTypeIconBase = (props: EntryTypeIconProps) => {
             zIndex="calc(var(--app-stickyheader-z-index) - 1)"
         >
             <Avatar
-                title={mapEntryTypeToName(props.entryType)}
-                color={mapEntryTypeToColor(props.entryType)}
+                title={mapEntryTypeToName(props.entry.entryType)}
+                color={mapEntryTypeToColor(props.entry.entryType)}
             >
                 <IconComponent className={classes.icon} />
             </Avatar>

--- a/src/features/Log/LogEntryEventMiniDetails/MiniDetailsEntry/MiniDetailsEntry.tsx
+++ b/src/features/Log/LogEntryEventMiniDetails/MiniDetailsEntry/MiniDetailsEntry.tsx
@@ -1,17 +1,27 @@
-import { Group, parseThemeColor, Text, useMantineTheme } from '@mantine/core';
+import {
+    Group,
+    MantineStyleProp,
+    parseThemeColor,
+    Text,
+    useMantineTheme,
+} from '@mantine/core';
 
 interface MiniDetailsEntryProps {
     icon: React.JSX.Element;
     title?: React.JSX.Element;
     size?: 'md' | 'sm';
+    shouldPreventShrink?: boolean;
 }
 
 export const MiniDetailsEntry = (props: MiniDetailsEntryProps) => {
-    const { icon, title, size = 'md' } = props;
+    const { icon, title, size = 'md', shouldPreventShrink = false } = props;
     const theme = useMantineTheme();
 
     return (
-        <Group gap="0.25rem">
+        <Group
+            gap="0.25rem"
+            style={shouldPreventShrink ? stylesWithPreventShrink : undefined}
+        >
             <icon.type
                 size={sizings[size].iconSize}
                 stroke={1.5}
@@ -35,3 +45,5 @@ const sizings = {
         fontSize: 14,
     },
 };
+
+const stylesWithPreventShrink = { flexShrink: 0 } satisfies MantineStyleProp;

--- a/src/features/Log/LogFilters/LogFilters.tsx
+++ b/src/features/Log/LogFilters/LogFilters.tsx
@@ -25,10 +25,14 @@ export const LogFilters = (props: LogFiltersProps) => {
         useDisclosure(false);
 
     const [filters, setFilters] = useState(defaultFilters);
+    const [prevFilters, setPrevFilters] = useState(filters);
 
     useEffect(() => {
-        onChange(filters);
-    }, [onChange, filters]);
+        if (filters !== prevFilters) {
+            setPrevFilters(filters);
+            onChange(filters);
+        }
+    }, [onChange, filters, prevFilters]);
 
     const onLogTypeChange = useCallback((value: string[]) => {
         setFilters((prev) => {

--- a/src/features/Log/LogFilters/LogTypeCombobox.tsx
+++ b/src/features/Log/LogFilters/LogTypeCombobox.tsx
@@ -33,10 +33,14 @@ export const LogTypeCombobox = (props: LogTypeComboboxProps) => {
     });
 
     const [value, setValue] = useState<string[]>([]);
+    const [prevValue, setPrevValue] = useState(value);
 
     useEffect(() => {
-        onChange(value);
-    }, [onChange, value]);
+        if (value !== prevValue) {
+            setPrevValue(value);
+            onChange(value);
+        }
+    }, [onChange, prevValue, value]);
 
     const handleValueSelect = (value: string) => {
         setValue((current) =>

--- a/src/features/Statistics/RoutineChart/RoutineChart.tsx
+++ b/src/features/Statistics/RoutineChart/RoutineChart.tsx
@@ -30,8 +30,11 @@ export const RoutineChart = (props: RoutineChartProps) => {
 
     const theme = useMantineTheme();
 
+    /**
+     * TODO: Make this chart more responsive
+     */
     return (
-        <PieChart width={400} height={400}>
+        <PieChart width={360} height={400}>
             {entriesPerDay.map((dayProps, index) => {
                 const dayLabel = dayProps.date.format(DEFAULT_DATE_FORMAT);
 
@@ -137,6 +140,6 @@ const TooltipContent = (props: {
     );
 };
 
-const radiusStartOffset = 30;
+const radiusStartOffset = 25;
 const radius = 20;
-const ringSpacing = 5;
+const ringSpacing = 4;


### PR DESCRIPTION
# Changelog

- Log entries jumping fix
  - Caused by elements shrinking causing layout shifts & re-renders due to visibility changes
- Log page optimization
  - Benchmarking case: Firefox, mobile display, `~1000` log entries, rendering on PC
  - Rendering speedup: `~800ms` -> `~300ms`
  - Changes:
    - Moved more stuff to deferred rendering (based on screen visibility; not virtualized yet)
    - Fixed unnecessary re-rendering caused by filters
- Routine chart made slightly smaller to fit on more mobile screen sizes