### PR TITLE
feat: Add medicine name & active substance suggestions

### DIFF
--- a/src/common/utils/typeGuards.ts
+++ b/src/common/utils/typeGuards.ts
@@ -1,0 +1,5 @@
+export const isNotNullable = <T>(
+    value: T
+): value is NonNullable<typeof value> => {
+    return value !== null && value !== undefined;
+};

--- a/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
+++ b/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
@@ -41,7 +41,6 @@ export const AddMedicineEvent = () => {
         validateField,
     } = useForm<MedicineEventFormSchema>({
         mode: 'uncontrolled',
-        initialValues: medicineEventFormDefaultValues,
         validate: medicineEventFormValidation,
         validateInputOnChange: true,
     });

--- a/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
+++ b/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
@@ -92,6 +92,7 @@ export const AddMedicineEvent = () => {
                 {...getInputProps('medicineName')}
                 data={knownMedicineNames}
                 comboboxProps={{ shadow: 'md' }}
+                maxDropdownHeight={200}
             />
             <Autocomplete
                 label="Medicine active substance"
@@ -101,6 +102,7 @@ export const AddMedicineEvent = () => {
                 {...getInputProps('medicineActiveSubstance')}
                 data={knownMedicineActiveSubstances}
                 comboboxProps={{ shadow: 'md' }}
+                maxDropdownHeight={200}
             />
             <MedicineDoseTypeInput
                 label="Dose type"

--- a/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
+++ b/src/features/EventEditor/AddEvent/AddMedicineEvent/AddMedicineEvent.tsx
@@ -1,4 +1,4 @@
-import { Box, TextInput } from '@mantine/core';
+import { Autocomplete, Box } from '@mantine/core';
 import { useAppStore } from '../../../../common/store/store';
 import {
     EntryType,
@@ -20,12 +20,17 @@ import {
     MedicineEventFormSchema,
     medicineEventFormValidation,
 } from '../../common/formSchemas/medicineEventForm.schema';
+import { useUniqueMedicineKinds } from '../../common/utils/useUniqueMedicineKinds';
 
 const eventType = EntryType.Medicine;
 
 export const AddMedicineEvent = () => {
     const addEntry = useAppStore((store) => store.api.addEntry);
+    const allEntries = useAppStore((state) => state.data.logs);
     const navigate = useNavigate();
+
+    const { knownMedicineNames, knownMedicineActiveSubstances } =
+        useUniqueMedicineKinds(allEntries);
 
     const {
         onSubmit: onFormSubmit,
@@ -80,18 +85,22 @@ export const AddMedicineEvent = () => {
 
     const middle = (
         <>
-            <TextInput
+            <Autocomplete
                 label="Medicine name"
                 placeholder="Eg. Nurofen"
                 key={formKey('medicineName')}
                 {...getInputProps('medicineName')}
+                data={knownMedicineNames}
+                comboboxProps={{ shadow: 'md' }}
             />
-            <TextInput
+            <Autocomplete
                 label="Medicine active substance"
                 placeholder="Eg. Ibuprofen"
                 mt="md"
                 key={formKey('medicineActiveSubstance')}
                 {...getInputProps('medicineActiveSubstance')}
+                data={knownMedicineActiveSubstances}
+                comboboxProps={{ shadow: 'md' }}
             />
             <MedicineDoseTypeInput
                 label="Dose type"

--- a/src/features/EventEditor/ModifyEvent/EventDetailsModifier/DetailsModifyMedicineEvent/DetailsModifyMedicineEvent.tsx
+++ b/src/features/EventEditor/ModifyEvent/EventDetailsModifier/DetailsModifyMedicineEvent/DetailsModifyMedicineEvent.tsx
@@ -1,4 +1,4 @@
-import { Box, TextInput } from '@mantine/core';
+import { Autocomplete, Box } from '@mantine/core';
 import {
     EntryType,
     LogEntry,
@@ -14,6 +14,8 @@ import {
     MedicineEventFormSchema,
     medicineEventFormValidation,
 } from '../../../common/formSchemas/medicineEventForm.schema';
+import { useAppStore } from '../../../../../common/store/store';
+import { useUniqueMedicineKinds } from '../../../common/utils/useUniqueMedicineKinds';
 
 interface DetailsModifyMedicineEventProps {
     event: LogEntry & { entryType: EntryType.Medicine };
@@ -24,6 +26,10 @@ export const DetailsModifyMedicineEvent = (
     props: DetailsModifyMedicineEventProps
 ) => {
     const { event, registerEventModifier } = props;
+    const allEntries = useAppStore((state) => state.data.logs);
+
+    const { knownMedicineNames, knownMedicineActiveSubstances } =
+        useUniqueMedicineKinds(allEntries);
 
     const {
         key: formKey,
@@ -107,18 +113,22 @@ export const DetailsModifyMedicineEvent = (
     return (
         <>
             <Box>
-                <TextInput
+                <Autocomplete
                     label="Medicine name"
                     placeholder="Eg. Nurofen"
                     key={formKey('medicineName')}
                     {...getInputProps('medicineName')}
+                    data={knownMedicineNames}
+                    comboboxProps={{ shadow: 'md' }}
                 />
-                <TextInput
+                <Autocomplete
                     label="Medicine active substance"
                     placeholder="Eg. Ibuprofen"
                     mt="md"
                     key={formKey('medicineActiveSubstance')}
                     {...getInputProps('medicineActiveSubstance')}
+                    data={knownMedicineActiveSubstances}
+                    comboboxProps={{ shadow: 'md' }}
                 />
                 <MedicineDoseTypeInput
                     label="Dose type"

--- a/src/features/EventEditor/ModifyEvent/EventDetailsModifier/DetailsModifyMedicineEvent/DetailsModifyMedicineEvent.tsx
+++ b/src/features/EventEditor/ModifyEvent/EventDetailsModifier/DetailsModifyMedicineEvent/DetailsModifyMedicineEvent.tsx
@@ -120,6 +120,7 @@ export const DetailsModifyMedicineEvent = (
                     {...getInputProps('medicineName')}
                     data={knownMedicineNames}
                     comboboxProps={{ shadow: 'md' }}
+                    maxDropdownHeight={200}
                 />
                 <Autocomplete
                     label="Medicine active substance"
@@ -129,6 +130,7 @@ export const DetailsModifyMedicineEvent = (
                     {...getInputProps('medicineActiveSubstance')}
                     data={knownMedicineActiveSubstances}
                     comboboxProps={{ shadow: 'md' }}
+                    maxDropdownHeight={200}
                 />
                 <MedicineDoseTypeInput
                     label="Dose type"

--- a/src/features/EventEditor/common/MedicineDoseInput/MedicineDoseInput.tsx
+++ b/src/features/EventEditor/common/MedicineDoseInput/MedicineDoseInput.tsx
@@ -27,6 +27,7 @@ export const MedicineDoseInput = (props: MedicineDoseInputProps) => {
             clampBehavior="strict"
             thousandSeparator=" "
             allowNegative={false}
+            allowLeadingZeros={false}
             {...baseProps}
         />
     );

--- a/src/features/EventEditor/common/utils/useUniqueMedicineKinds.ts
+++ b/src/features/EventEditor/common/utils/useUniqueMedicineKinds.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import {
+    EntryType,
+    LogEntry,
+} from '../../../../common/store/types/storeData.types';
+import { isNotNullable } from '../../../../common/utils/typeGuards';
+
+export const useUniqueMedicineKinds = (entries: LogEntry[]) => {
+    const allMedicineEntries = useMemo(() => {
+        return entries.filter(
+            (entry) => entry.entryType === EntryType.Medicine
+        );
+    }, [entries]);
+
+    return useMemo(() => {
+        const uniqueNames = new Set(
+            allMedicineEntries.map((entry) => entry.params.medicineName)
+        );
+        const uniqueActiveSubstances = new Set(
+            allMedicineEntries.map(
+                (entry) => entry.params.medicineActiveSubstance
+            )
+        );
+
+        return {
+            knownMedicineNames: [...uniqueNames.values()].filter(isNotNullable),
+            knownMedicineActiveSubstances: [
+                ...uniqueActiveSubstances.values(),
+            ].filter(isNotNullable),
+        };
+    }, [allMedicineEntries]);
+};


### PR DESCRIPTION
# Changelog

- Added medicine name & active substance suggestions based on previous inputs
  - _Note:_ due to how entry logs are stored, this might eventually need some optimizations. However, since the general storage itself should be optimized for more memo-friendly lookups, this potential performance problem will resolve itself.
- Medicise dose no longer allows leading zeros (for easier operations)
- When adding new medicine entry, form is no longer filled with defaults
  - This should make it easier to input dose value right away