### PR TITLE
feat: Duplicate medicine event

### DIFF
--- a/src/common/hooks/useDuplicateEntry.ts
+++ b/src/common/hooks/useDuplicateEntry.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { useAppStore } from '../store/store';
+import { useNavigate } from 'react-router';
+import { LogEntry } from '../store/types/storeData.types';
+import { createNewEvent } from '../store/store.utils';
+import { routes } from '../routes';
+import { isTimedEntry } from '../utils/entryGuards';
+
+export const useDuplicateEntry = () => {
+    const addEntry = useAppStore((store) => store.api.addEntry);
+    const navigate = useNavigate();
+
+    const duplicateEntry = useCallback(
+        (event: LogEntry) => {
+            if (isTimedEntry(event)) {
+                console.warn(
+                    'useDuplicateEntry: TimedEntries are not currently supported, ignoring...'
+                );
+                return;
+            }
+
+            const newEntry = addEntry(
+                createNewEvent(({ metadata }) => {
+                    const newEvent = window.structuredClone(event);
+
+                    newEvent.metadata = metadata;
+
+                    return newEvent;
+                })
+            );
+
+            void navigate(routes.eventView(newEntry.metadata.uid), {
+                // TODO: This probably should be configurable?
+                replace: true,
+            });
+        },
+        [addEntry, navigate]
+    );
+
+    return {
+        duplicateEntry,
+    };
+};

--- a/src/features/EventEditor/ViewEvent/CompleteEvent/CompleteEvent.tsx
+++ b/src/features/EventEditor/ViewEvent/CompleteEvent/CompleteEvent.tsx
@@ -1,15 +1,20 @@
 import { Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconPencil, IconTrash } from '@tabler/icons-react';
+import { IconCopy, IconPencil, IconTrash } from '@tabler/icons-react';
 import { useNavigate, Link } from 'react-router';
 import { ResponsiveButton } from '../../../../common/design/ResponsiveButton';
 import { ResponsiveStack } from '../../../../common/design/ResponsiveStack';
 import { EntryDeleteModal } from '../../../../common/features/EntryDeleteModal/EntryDeleteModal';
-import { LogEntry } from '../../../../common/store/types/storeData.types';
+import {
+    EntryType,
+    LogEntry,
+} from '../../../../common/store/types/storeData.types';
 import { EventCard } from '../../common/EventCard/EventCard';
 import { EventDetails } from '../EventDetails/EventDetails';
 import { EventNotes } from './EventNotes/EventNotes';
 import { routes } from '../../../../common/routes';
+import { useDuplicateEntry } from '../../../../common/hooks/useDuplicateEntry';
+import { useMemo } from 'react';
 
 interface CompleteEventProps {
     event: LogEntry;
@@ -17,12 +22,39 @@ interface CompleteEventProps {
 
 export const CompleteEvent = (props: CompleteEventProps) => {
     const { event } = props;
+    const { duplicateEntry } = useDuplicateEntry();
     const navigate = useNavigate();
 
     const [
         isConfirmDeleteOpen,
         { open: openConfirmDelete, close: closeConfirmDelete },
     ] = useDisclosure(false);
+
+    const specificActions = useMemo(() => {
+        if (event.entryType === EntryType.Medicine) {
+            const handleDuplicateEntry = () => {
+                duplicateEntry(event);
+            };
+
+            return (
+                <ResponsiveStack>
+                    <ResponsiveButton
+                        variant="light"
+                        color="grape"
+                        fullWidth
+                        onClick={handleDuplicateEntry}
+                    >
+                        <IconCopy />
+                        <Text component="span" ml="0.25rem">
+                            Duplicate (with current date)
+                        </Text>
+                    </ResponsiveButton>
+                </ResponsiveStack>
+            );
+        }
+
+        return;
+    }, [duplicateEntry, event]);
 
     return (
         <>
@@ -31,6 +63,7 @@ export const CompleteEvent = (props: CompleteEventProps) => {
                 middle={[
                     <EventDetails event={event} />,
                     <EventNotes event={event} />,
+                    specificActions,
                 ]}
                 footer={
                     <ResponsiveStack>

--- a/src/features/EventEditor/common/EventCard/EventCard.tsx
+++ b/src/features/EventEditor/common/EventCard/EventCard.tsx
@@ -88,6 +88,10 @@ export const EventCard = (props: EventCardProps) => {
             </Text>
 
             {Children.map(middle, (child) => {
+                if (!child) {
+                    return;
+                }
+
                 return (
                     <Box className={classes.sectionWithDivider}>{child}</Box>
                 );

--- a/src/features/Log/LogEntryDisplay.tsx
+++ b/src/features/Log/LogEntryDisplay.tsx
@@ -91,7 +91,7 @@ const LogEntryDisplayBase = (props: LogEntryProps) => {
             >
                 {inViewport && (
                     <EntryActions
-                        entryUid={entry.metadata.uid}
+                        event={entry}
                         onOpenConfirmDelete={handleOpenConfirmDelete}
                     />
                 )}

--- a/src/features/Log/LogEntryDisplay/EntryActions.tsx
+++ b/src/features/Log/LogEntryDisplay/EntryActions.tsx
@@ -1,17 +1,48 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ActionIcon, Menu } from '@mantine/core';
 
 import classes from './EntryActions.module.css';
-import { IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
+import { IconCopy, IconDots, IconPencil, IconTrash } from '@tabler/icons-react';
 import { Link } from 'react-router';
 import { routes } from '../../../common/routes';
+import {
+    EntryType,
+    LogEntry,
+} from '../../../common/store/types/storeData.types';
+import { useDuplicateEntry } from '../../../common/hooks/useDuplicateEntry';
 
 interface EntryActionsProps {
-    entryUid: string;
+    event: LogEntry;
     onOpenConfirmDelete: () => void;
 }
 
 const EntryActionsBase = (props: EntryActionsProps) => {
+    const { event, onOpenConfirmDelete } = props;
+    const { duplicateEntry } = useDuplicateEntry();
+
+    const specificActions = useMemo(() => {
+        if (event.entryType === EntryType.Medicine) {
+            const handleDuplicateEntry = () => {
+                duplicateEntry(event);
+            };
+
+            return (
+                <>
+                    <Menu.Item
+                        leftSection={
+                            <IconCopy className={classes.menuItemIcon} />
+                        }
+                        onClick={handleDuplicateEntry}
+                    >
+                        Duplicate (with current date)
+                    </Menu.Item>
+                </>
+            );
+        }
+
+        return;
+    }, [duplicateEntry, event]);
+
     return (
         <Menu shadow="md" position="bottom-end">
             <Menu.Target>
@@ -20,19 +51,25 @@ const EntryActionsBase = (props: EntryActionsProps) => {
                 </ActionIcon>
             </Menu.Target>
             <Menu.Dropdown>
+                {specificActions && (
+                    <>
+                        {specificActions}
+                        <Menu.Divider />
+                    </>
+                )}
                 <Menu.Item
                     component={Link}
                     leftSection={
                         <IconPencil className={classes.menuItemIcon} />
                     }
-                    to={routes.eventEdit(props.entryUid)}
+                    to={routes.eventEdit(event.metadata.uid)}
                 >
                     Edit entry
                 </Menu.Item>
                 <Menu.Item
                     color="red"
                     leftSection={<IconTrash className={classes.menuItemIcon} />}
-                    onClick={props.onOpenConfirmDelete}
+                    onClick={onOpenConfirmDelete}
                 >
                     Delete entry
                 </Menu.Item>


### PR DESCRIPTION
# Changelog:

- Added "Duplicate" action for `EntryType.Medicine` log entries
  - Available in context menu (both Log view & Recent events)
  - Available in event view